### PR TITLE
Add new map classes

### DIFF
--- a/railroads/engine.py
+++ b/railroads/engine.py
@@ -4,9 +4,10 @@ from amethyst.games import action, Engine, EnginePlugin, Filter
 from amethyst.games.util import random
 from amethyst.games.plugins import GrantManager, Grant, Turns
 
+from . import maps
+
 
 class RailroadEngine(Engine):
-    map = Attr()
     draw_pile = Attr(default=list)
     discard_pile = Attr(default=list)
 
@@ -16,6 +17,7 @@ class RailroadEngine(Engine):
         # Most turn-based games will want the GrantManager and Turns plugin
         self.register_plugin(GrantManager())
         self.register_plugin(Turns(setup_rounds=(1, -1)))
+        self.register_plugin(maps.HexmapContainer())
 
 
 class RailroadPlugin(EnginePlugin):

--- a/railroads/maps.py
+++ b/railroads/maps.py
@@ -1,59 +1,73 @@
 from enum import Enum
 
 from amethyst.core import Object, Attr, dict_of
-from amethyst.games import Filterable
+from amethyst.games import EnginePlugin
 
 
-class Hex(Filterable):
-    coordinates = Attr()
+DIRECTIONS = {
+    'row': [(2, 0), (1, -1), (-1, -1), (-2, 0), (-1, 1), (1, 1)],
+    'column': [(1, 1), (1, -1), (0, -2), (-1, -1), (-1, 1), (0, 2)],
+}
 
-    terrain = Attr()
 
+class HexmapContainer(EnginePlugin):
+    AMETHYST_PLUGIN_COMPAT = 1  # Plugin API version
+    AMETHYST_ENGINE_METHODS = [
+        'load_definition', 'load_hexes',
+        'contains', 'is_adjacent', 'adjacent'
+    ]
+    AMETHYST_ENGINE_DEFAULT_METHOD_PREFIX = "map_"
 
-class Hexmap(Object):
-    height = Attr(int)
-    width = Attr(int)
+    _maps = Attr(default=dict)
+    _terrain = Attr(default=dict)
 
-    hexes = Attr(default=dict)
+    def hexgrid_invariant(self, map_name, col, row):
+        if map_name not in self._maps:
+            return False
+        _, height, width = self._maps[map_name]
 
-    def _hexgrid_invariant(self, co):
-        col, row = co
-        if not (0 <= col <= self.width and 0 <= row <= self.height):
+        if not (0 <= col <= width and 0 <= row <= height):
             return False
         return (col + row) & 1 == 0
 
-    def __contains__(self, co):
-        if not self._hexgrid_invariant(co):
-            return False
-        if self.hexes and co not in self.hexes:
-            return False
-        return True
+    def load_definition(self, game, data):
+        for name, _type, height, width in data:
+            if _type not in DIRECTIONS:
+                continue
+            self._maps[name] = (_type, height, width)
 
-    def register_hexes(self, data):
+    def load_hexes(self, game, data):
         terrain_types = Enum('Terrain', ' '.join(t.upper() for t in data))
-        for t_name, coordinates in data.items():
+        for t_name, maps in data.items():
             t = terrain_types[t_name.upper()]
-            for co in coordinates:
-                if not self._hexgrid_invariant(co):
-                    continue
-                self.hexes[co] = Hex(coordinates=co, terrain=t)
+            for map_name, coordinates in maps.items():
+                for col, row in coordinates:
+                    if not self.hexgrid_invariant(map_name, col, row):
+                        continue
+                    self._terrain[(map_name, col, row)] = t
 
-
-class StraightRowHexmap(Hexmap):
-    def is_adjacent(self, co1, co2):
-        if co1 not in self or co2 not in self:
+    def contains(self, game, coordinates):
+        if not self.hexgrid_invariant(*coordinates):
             return False
-        c, r = co1
+        return coordinates in self._terrain
+
+    def is_adjacent(self, game, co1, co2):
+        if co1[0] != co2[0]:
+            return False
+        if not self.contains(game, co1) or not self.contains(game, co2):
+            return False
+        map_name, col, row = co1
         return any(
-            (c + dc, r + dr) == co2 for dc, dr in [(2, 0), (1, -1), (-1, -1), (-2, 0), (-1, 1), (1, 1)]
+            (map_name, col + dc, row + dr) == co2
+            for dc, dr in DIRECTIONS[self._maps[map_name][0]]
         )
 
-
-class StraightColumnHexmap(Hexmap):
-    def is_adjacent(self, co1, co2):
-        if co1 not in self or co2 not in self:
-            return False
-        c, r = co1
-        return any(
-            (c + dc, r + dr) == co2 for dc, dr in [(1, 1), (1, -1), (0, -2), (-1, -1), (-1, 1), (0, 2)]
-        )
+    def adjacent(self, game, coordinates):
+        if not self.contains(game, coordinates):
+            return []
+        map_name, col, row = coordinates
+        return [
+            (map_name, col + dc, row + dr)
+            for dc, dr in DIRECTIONS[self._maps[map_name][0]]
+            if self.contains(game, (map_name, col + dc, row + dr))
+        ]

--- a/railroads/maps.py
+++ b/railroads/maps.py
@@ -1,16 +1,35 @@
+from enum import Enum
 
-from amethyst.core  import Object, Attr
+from amethyst.core import Object, Attr, dict_of
 
 
 class Hexmap(Object):
-    height = Attr()
-    width = Attr()
+    height = Attr(int)
+    width = Attr(int)
 
-    def __contains__(self, coordinates):
-        col, row = coordinates
+    terrain = Attr(dict_of(int), default=dict)
+
+    def _hexgrid_invariant(self, co):
+        col, row = co
         if not (0 <= col <= self.width and 0 <= row <= self.height):
             return False
         return (col + row) & 1 == 0
+
+    def __contains__(self, co):
+        if not self._hexgrid_invariant(co):
+            return False
+        if self.terrain and co not in self.terrain:
+            return False
+        return True
+
+    def register_terrain(self, data):
+        terrain_types = Enum('Terrain', ' '.join(t.upper() for t in data))
+        for t_name, coordinates in data.items():
+            t = terrain_types[t_name.upper()]
+            for co in coordinates:
+                if not self._hexgrid_invariant(co):
+                    continue
+                self.terrain[co] = t
 
 
 class StraightRowHexmap(Hexmap):

--- a/railroads/maps.py
+++ b/railroads/maps.py
@@ -1,0 +1,21 @@
+
+from amethyst.core  import Object, Attr
+
+
+class Hexmap(Object):
+    height = Attr()
+    width = Attr()
+
+    def __contains__(self, coordinates):
+        col, row = coordinates
+        if not (0 <= col <= self.width and 0 <= row <= self.height):
+            return False
+        return (col + row) & 1 == 0
+
+
+class StraightRowHexmap(Hexmap):
+    pass
+
+
+class StraightColumnHexmap(Hexmap):
+    pass

--- a/railroads/maps.py
+++ b/railroads/maps.py
@@ -14,8 +14,20 @@ class Hexmap(Object):
 
 
 class StraightRowHexmap(Hexmap):
-    pass
+    def is_adjacent(self, co1, co2):
+        if co1 not in self or co2 not in self:
+            return False
+        c, r = co1
+        return any(
+            (c + dc, r + dr) == co2 for dc, dr in [(2, 0), (1, -1), (-1, -1), (-2, 0), (-1, 1), (1, 1)]
+        )
 
 
 class StraightColumnHexmap(Hexmap):
-    pass
+    def is_adjacent(self, co1, co2):
+        if co1 not in self or co2 not in self:
+            return False
+        c, r = co1
+        return any(
+            (c + dc, r + dr) == co2 for dc, dr in [(1, 1), (1, -1), (0, -2), (-1, -1), (-1, 1), (0, 2)]
+        )

--- a/railroads/maps.py
+++ b/railroads/maps.py
@@ -1,13 +1,20 @@
 from enum import Enum
 
 from amethyst.core import Object, Attr, dict_of
+from amethyst.games import Filterable
+
+
+class Hex(Filterable):
+    coordinates = Attr()
+
+    terrain = Attr()
 
 
 class Hexmap(Object):
     height = Attr(int)
     width = Attr(int)
 
-    terrain = Attr(dict_of(int), default=dict)
+    hexes = Attr(default=dict)
 
     def _hexgrid_invariant(self, co):
         col, row = co
@@ -18,18 +25,18 @@ class Hexmap(Object):
     def __contains__(self, co):
         if not self._hexgrid_invariant(co):
             return False
-        if self.terrain and co not in self.terrain:
+        if self.hexes and co not in self.hexes:
             return False
         return True
 
-    def register_terrain(self, data):
+    def register_hexes(self, data):
         terrain_types = Enum('Terrain', ' '.join(t.upper() for t in data))
         for t_name, coordinates in data.items():
             t = terrain_types[t_name.upper()]
             for co in coordinates:
                 if not self._hexgrid_invariant(co):
                     continue
-                self.terrain[co] = t
+                self.hexes[co] = Hex(coordinates=co, terrain=t)
 
 
 class StraightRowHexmap(Hexmap):

--- a/tests/test_maps.py
+++ b/tests/test_maps.py
@@ -1,0 +1,45 @@
+import unittest
+
+from railroads import maps
+
+
+class StraightRowHexmapTest(unittest.TestCase):
+    def setUp(self):
+        self.map = maps.StraightRowHexmap(width=8, height=8)
+
+    def test_in_bounds(self):
+        for r in range(8):
+            for c in range(r & 1, 8, 2):
+                self.assertIn((c, r), self.map)
+
+    def test_wrong_phase(self):
+        for r in range(8):
+            for c in range((r + 1) & 1, 8, 2):
+                self.assertNotIn((c, r), self.map)
+
+    def test_out_of_bounds(self):
+        self.assertNotIn((-1, 5), self.map)
+        self.assertNotIn((3, -1), self.map)
+        self.assertNotIn((10, 6), self.map)
+        self.assertNotIn((2, 12), self.map)
+
+
+class StraightColumnHexmapTest(unittest.TestCase):
+    def setUp(self):
+        self.map = maps.StraightColumnHexmap(width=8, height=8)
+
+    def test_in_bounds(self):
+        for c in range(8):
+            for r in range(c & 1, 8, 2):
+                self.assertIn((c, r), self.map)
+
+    def test_wrong_phase(self):
+        for c in range(8):
+            for r in range((c + 1) & 1, 8, 2):
+                self.assertNotIn((c, r), self.map)
+
+    def test_out_of_bounds(self):
+        self.assertNotIn((-1, 5), self.map)
+        self.assertNotIn((3, -1), self.map)
+        self.assertNotIn((10, 6), self.map)
+        self.assertNotIn((2, 12), self.map)

--- a/tests/test_maps.py
+++ b/tests/test_maps.py
@@ -23,6 +23,19 @@ class StraightRowHexmapTest(unittest.TestCase):
         self.assertNotIn((10, 6), self.map)
         self.assertNotIn((2, 12), self.map)
 
+    def test_is_adjacent(self):
+        for co in [(3, 3), (5, 3), (2, 4), (6, 4), (3, 5), (5, 5)]:
+            self.assertTrue(self.map.is_adjacent((4, 4), co))
+
+    def test_not_adjacent_off_the_edge(self):
+        self.assertFalse(self.map.is_adjacent((6, 0), (7, -1)))
+
+    def test_not_adjacent_too_far(self):
+        self.assertFalse(self.map.is_adjacent((5, 3), (7, 1)))
+
+    def test_not_adjacent_wrong_phase(self):
+        self.assertFalse(self.map.is_adjacent((3, 3), (4, 3)))
+
 
 class StraightColumnHexmapTest(unittest.TestCase):
     def setUp(self):
@@ -43,3 +56,16 @@ class StraightColumnHexmapTest(unittest.TestCase):
         self.assertNotIn((3, -1), self.map)
         self.assertNotIn((10, 6), self.map)
         self.assertNotIn((2, 12), self.map)
+
+    def test_is_adjacent(self):
+        for co in [(3, 3), (3, 5), (4, 2), (4, 6), (5, 3), (5, 5)]:
+            self.assertTrue(self.map.is_adjacent((4, 4), co))
+
+    def test_not_adjacent_off_the_edge(self):
+        self.assertFalse(self.map.is_adjacent((6, 0), (5, -1)))
+
+    def test_not_adjacent_too_far(self):
+        self.assertFalse(self.map.is_adjacent((5, 3), (7, 1)))
+
+    def test_not_adjacent_wrong_phase(self):
+        self.assertFalse(self.map.is_adjacent((3, 3), (4, 3)))

--- a/tests/test_maps.py
+++ b/tests/test_maps.py
@@ -41,12 +41,12 @@ class StraightRowHexmapTest(unittest.TestCase):
         plains = [(c, r) for r in range(3) for c in range(5)]
         mountains = [(c, r) for r in range(3, 5) for c in range(5)]
         data = {'plain': plains, 'mountain': mountains}
-        _map.register_terrain(data)
-        terrain = type(_map.terrain[(0, 0)])
+        _map.register_hexes(data)
+        terrain = type(_map.hexes[(0, 0)].terrain)
 
-        self.assertEqual(len(_map.terrain), 13)
-        self.assertEqual(sum(1 for co, T in _map.terrain.items() if T == terrain.PLAIN), 8)
-        self.assertEqual(sum(1 for co, T in _map.terrain.items() if T == terrain.MOUNTAIN), 5)
+        self.assertEqual(len(_map.hexes), 13)
+        self.assertEqual(sum(1 for co, H in _map.hexes.items() if H.terrain == terrain.PLAIN), 8)
+        self.assertEqual(sum(1 for co, H in _map.hexes.items() if H.terrain == terrain.MOUNTAIN), 5)
 
 
 class StraightColumnHexmapTest(unittest.TestCase):
@@ -87,9 +87,9 @@ class StraightColumnHexmapTest(unittest.TestCase):
         plains = [(c, r) for r in range(3) for c in range(5)]
         mountains = [(c, r) for r in range(3, 5) for c in range(5)]
         data = {'plain': plains, 'mountain': mountains}
-        _map.register_terrain(data)
-        terrain = type(_map.terrain[(0, 0)])
+        _map.register_hexes(data)
+        terrain = type(_map.hexes[(0, 0)].terrain)
 
-        self.assertEqual(len(_map.terrain), 13)
-        self.assertEqual(sum(1 for co, T in _map.terrain.items() if T == terrain.PLAIN), 8)
-        self.assertEqual(sum(1 for co, T in _map.terrain.items() if T == terrain.MOUNTAIN), 5)
+        self.assertEqual(len(_map.hexes), 13)
+        self.assertEqual(sum(1 for co, H in _map.hexes.items() if H.terrain == terrain.PLAIN), 8)
+        self.assertEqual(sum(1 for co, H in _map.hexes.items() if H.terrain == terrain.MOUNTAIN), 5)

--- a/tests/test_maps.py
+++ b/tests/test_maps.py
@@ -141,5 +141,66 @@ class HexmapContainerColumnTest(unittest.TestCase):
 #         self.assertEqual(sum(1 for co, H in _map.hexes.items() if H.terrain == terrain.MOUNTAIN), 5)
 
 
+class HexmapContainerMultiTest(unittest.TestCase):
+    def setUp(self):
+        self.game = engine.RailroadEngine()
+        data = [('left', 'row', 5, 5), ('right', 'row', 5, 5)]
+        self.game.map_load_definition(data)
+
+        data = {
+            'plain': {
+                'left': [(c, r) for c in range(5) for r in range(5)],
+                'right': [(c, r) for c in range(5) for r in range(5)]
+            }
+        }
+        self.game.map_load_hexes(data)
+
+        self.game.map_load_equivalents([(('left', 2, 2), ('right', 2, 2))])
+
+    def test_adjacent_list_from_equiv(self):
+        self.assertCountEqual(
+            self.game.map_adjacent(('left', 2, 2)),
+            [('left', 1, 1), ('left', 3, 1), ('left', 0, 2),
+             ('left', 4, 2), ('left', 1, 3), ('left', 3, 3),
+             ('right', 1, 1), ('right', 3, 1), ('right', 0, 2),
+             ('right', 4, 2), ('right', 1, 3), ('right', 3, 3)]
+        )
+        self.assertCountEqual(
+            self.game.map_adjacent(('right', 2, 2)),
+            [('left', 1, 1), ('left', 3, 1), ('left', 0, 2),
+             ('left', 4, 2), ('left', 1, 3), ('left', 3, 3),
+             ('right', 1, 1), ('right', 3, 1), ('right', 0, 2),
+             ('right', 4, 2), ('right', 1, 3), ('right', 3, 3)]
+        )
+
+    def test_adjacent_list_next_to_equiv(self):
+        self.assertCountEqual(
+            self.game.map_adjacent(('left', 1, 1)),
+            [('left', 0, 0), ('left', 2, 0), ('left', 3, 1), ('left', 0, 2), ('left', 2, 2), ('right', 2, 2)]
+        )
+        self.assertCountEqual(
+            self.game.map_adjacent(('right', 1, 1)),
+            [('right', 0, 0), ('right', 2, 0), ('right', 3, 1), ('right', 0, 2), ('right', 2, 2), ('left', 2, 2)]
+        )
+
+    def test_adjacent_list_too_far(self):
+        self.assertCountEqual(
+            self.game.map_adjacent(('left', 0, 0)),
+            [('left', 2, 0), ('left', 1, 1)]
+        )
+        self.assertCountEqual(
+            self.game.map_adjacent(('right', 0, 0)),
+            [('right', 2, 0), ('right', 1, 1)]
+        )
+
+    def test_is_adjacent_from_equiv(self):
+        self.assertTrue(self.game.map_is_adjacent(('left', 2, 2), ('right', 3, 1)))
+        self.assertTrue(self.game.map_is_adjacent(('right', 2, 2), ('left', 3, 1)))
+
+    def test_is_adjacent_next_to_equiv(self):
+        self.assertTrue(self.game.map_is_adjacent(('left', 3, 1), ('right', 2, 2)))
+        self.assertTrue(self.game.map_is_adjacent(('right', 3, 1), ('left', 2, 2)))
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_maps.py
+++ b/tests/test_maps.py
@@ -36,6 +36,18 @@ class StraightRowHexmapTest(unittest.TestCase):
     def test_not_adjacent_wrong_phase(self):
         self.assertFalse(self.map.is_adjacent((3, 3), (4, 3)))
 
+    def test_terrain(self):
+        _map = maps.StraightRowHexmap(width=5, height=5)
+        plains = [(c, r) for r in range(3) for c in range(5)]
+        mountains = [(c, r) for r in range(3, 5) for c in range(5)]
+        data = {'plain': plains, 'mountain': mountains}
+        _map.register_terrain(data)
+        terrain = type(_map.terrain[(0, 0)])
+
+        self.assertEqual(len(_map.terrain), 13)
+        self.assertEqual(sum(1 for co, T in _map.terrain.items() if T == terrain.PLAIN), 8)
+        self.assertEqual(sum(1 for co, T in _map.terrain.items() if T == terrain.MOUNTAIN), 5)
+
 
 class StraightColumnHexmapTest(unittest.TestCase):
     def setUp(self):
@@ -69,3 +81,15 @@ class StraightColumnHexmapTest(unittest.TestCase):
 
     def test_not_adjacent_wrong_phase(self):
         self.assertFalse(self.map.is_adjacent((3, 3), (4, 3)))
+
+    def test_terrain(self):
+        _map = maps.StraightRowHexmap(width=5, height=5)
+        plains = [(c, r) for r in range(3) for c in range(5)]
+        mountains = [(c, r) for r in range(3, 5) for c in range(5)]
+        data = {'plain': plains, 'mountain': mountains}
+        _map.register_terrain(data)
+        terrain = type(_map.terrain[(0, 0)])
+
+        self.assertEqual(len(_map.terrain), 13)
+        self.assertEqual(sum(1 for co, T in _map.terrain.items() if T == terrain.PLAIN), 8)
+        self.assertEqual(sum(1 for co, T in _map.terrain.items() if T == terrain.MOUNTAIN), 5)

--- a/tests/test_maps.py
+++ b/tests/test_maps.py
@@ -1,95 +1,145 @@
 import unittest
 
-from railroads import maps
+from railroads import engine, maps
 
 
-class StraightRowHexmapTest(unittest.TestCase):
+class HexmapContainerRowTest(unittest.TestCase):
     def setUp(self):
-        self.map = maps.StraightRowHexmap(width=8, height=8)
+        self.game = engine.RailroadEngine()
+        data = [('default', 'row', 5, 5)]
+        self.game.map_load_definition(data)
 
-    def test_in_bounds(self):
-        for r in range(8):
-            for c in range(r & 1, 8, 2):
-                self.assertIn((c, r), self.map)
-
-    def test_wrong_phase(self):
-        for r in range(8):
-            for c in range((r + 1) & 1, 8, 2):
-                self.assertNotIn((c, r), self.map)
-
-    def test_out_of_bounds(self):
-        self.assertNotIn((-1, 5), self.map)
-        self.assertNotIn((3, -1), self.map)
-        self.assertNotIn((10, 6), self.map)
-        self.assertNotIn((2, 12), self.map)
-
-    def test_is_adjacent(self):
-        for co in [(3, 3), (5, 3), (2, 4), (6, 4), (3, 5), (5, 5)]:
-            self.assertTrue(self.map.is_adjacent((4, 4), co))
-
-    def test_not_adjacent_off_the_edge(self):
-        self.assertFalse(self.map.is_adjacent((6, 0), (7, -1)))
-
-    def test_not_adjacent_too_far(self):
-        self.assertFalse(self.map.is_adjacent((5, 3), (7, 1)))
-
-    def test_not_adjacent_wrong_phase(self):
-        self.assertFalse(self.map.is_adjacent((3, 3), (4, 3)))
-
-    def test_terrain(self):
-        _map = maps.StraightRowHexmap(width=5, height=5)
         plains = [(c, r) for r in range(3) for c in range(5)]
         mountains = [(c, r) for r in range(3, 5) for c in range(5)]
-        data = {'plain': plains, 'mountain': mountains}
-        _map.register_hexes(data)
-        terrain = type(_map.hexes[(0, 0)].terrain)
-
-        self.assertEqual(len(_map.hexes), 13)
-        self.assertEqual(sum(1 for co, H in _map.hexes.items() if H.terrain == terrain.PLAIN), 8)
-        self.assertEqual(sum(1 for co, H in _map.hexes.items() if H.terrain == terrain.MOUNTAIN), 5)
-
-
-class StraightColumnHexmapTest(unittest.TestCase):
-    def setUp(self):
-        self.map = maps.StraightColumnHexmap(width=8, height=8)
+        data = {'plain': {'default': plains}, 'mountain': {'default': mountains}}
+        self.game.map_load_hexes(data)
 
     def test_in_bounds(self):
-        for c in range(8):
-            for r in range(c & 1, 8, 2):
-                self.assertIn((c, r), self.map)
+        for r in range(5):
+            for c in range(r & 1, 5, 2):
+                self.assertTrue(self.game.map_contains(('default', c, r)))
 
     def test_wrong_phase(self):
-        for c in range(8):
-            for r in range((c + 1) & 1, 8, 2):
-                self.assertNotIn((c, r), self.map)
+        for r in range(5):
+            for c in range((r + 1) & 1, 5, 2):
+                self.assertFalse(self.game.map_contains(('default', c, r)))
 
     def test_out_of_bounds(self):
-        self.assertNotIn((-1, 5), self.map)
-        self.assertNotIn((3, -1), self.map)
-        self.assertNotIn((10, 6), self.map)
-        self.assertNotIn((2, 12), self.map)
+        self.assertFalse(self.game.map_contains(('default', -1, 5)))
+        self.assertFalse(self.game.map_contains(('default', 3, -1)))
+        self.assertFalse(self.game.map_contains(('default', 6, 4)))
+        self.assertFalse(self.game.map_contains(('default', 2, 12)))
 
     def test_is_adjacent(self):
-        for co in [(3, 3), (3, 5), (4, 2), (4, 6), (5, 3), (5, 5)]:
-            self.assertTrue(self.map.is_adjacent((4, 4), co))
+        for col, row in [(1, 1), (3, 1), (0, 2), (4, 2), (1, 3), (3, 3)]:
+            self.assertTrue(
+                self.game.map_is_adjacent(('default', 2, 2), ('default', col, row)),
+                f"('default', {col}, {row}) is not adjacent to ('default', 2, 2)."
+            )
 
     def test_not_adjacent_off_the_edge(self):
-        self.assertFalse(self.map.is_adjacent((6, 0), (5, -1)))
+        self.assertFalse(self.game.map_is_adjacent(('default', 4, 0), ('default', 6, 0)))
 
     def test_not_adjacent_too_far(self):
-        self.assertFalse(self.map.is_adjacent((5, 3), (7, 1)))
+        self.assertFalse(self.game.map_is_adjacent(('default', 1, 3), ('default', 3, 1)))
 
     def test_not_adjacent_wrong_phase(self):
-        self.assertFalse(self.map.is_adjacent((3, 3), (4, 3)))
+        self.assertFalse(self.game.map_is_adjacent(('default', 3, 3), ('default', 4, 3)))
 
-    def test_terrain(self):
-        _map = maps.StraightRowHexmap(width=5, height=5)
+    def test_adjacent_list_middle(self):
+        self.assertCountEqual(
+            self.game.map_adjacent(('default', 2, 2)),
+            [('default', 1, 1), ('default', 3, 1), ('default', 0, 2),
+             ('default', 4, 2), ('default', 1, 3), ('default', 3, 3)]
+        )
+
+    def test_adjacent_list_edge(self):
+        self.assertCountEqual(
+            self.game.map_adjacent(('default', 4, 2)),
+            [('default', 3, 1), ('default', 2, 2), ('default', 3, 3)]
+        )
+
+    def test_adjacent_list_out_of_bounds(self):
+        self.assertCountEqual(self.game.map_adjacent(('default', 5, 5)), [])
+
+    def test_adjacent_list_wrong_phase(self):
+        self.assertCountEqual(self.game.map_adjacent(('default', 3, 2)), [])
+
+#     def test_terrain(self):
+#         terrain = type(_map.hexes[(0, 0)].terrain)
+#         self.assertEqual(len(_map.hexes), 13)
+#         self.assertEqual(sum(1 for co, H in _map.hexes.items() if H.terrain == terrain.PLAIN), 8)
+#         self.assertEqual(sum(1 for co, H in _map.hexes.items() if H.terrain == terrain.MOUNTAIN), 5)
+
+
+class HexmapContainerColumnTest(unittest.TestCase):
+    def setUp(self):
+        self.game = engine.RailroadEngine()
+        data = [('default', 'column', 5, 5)]
+        self.game.map_load_definition(data)
+
         plains = [(c, r) for r in range(3) for c in range(5)]
         mountains = [(c, r) for r in range(3, 5) for c in range(5)]
-        data = {'plain': plains, 'mountain': mountains}
-        _map.register_hexes(data)
-        terrain = type(_map.hexes[(0, 0)].terrain)
+        data = {'plain': {'default': plains}, 'mountain': {'default': mountains}}
+        self.game.map_load_hexes(data)
 
-        self.assertEqual(len(_map.hexes), 13)
-        self.assertEqual(sum(1 for co, H in _map.hexes.items() if H.terrain == terrain.PLAIN), 8)
-        self.assertEqual(sum(1 for co, H in _map.hexes.items() if H.terrain == terrain.MOUNTAIN), 5)
+    def test_in_bounds(self):
+        for c in range(5):
+            for r in range(c & 1, 5, 2):
+                self.assertTrue(self.game.map_contains(('default', c, r)))
+
+    def test_wrong_phase(self):
+        for c in range(5):
+            for r in range((c + 1) & 1, 5, 2):
+                self.assertFalse(self.game.map_contains(('default', c, r)))
+
+    def test_out_of_bounds(self):
+        self.assertFalse(self.game.map_contains(('default', -1, 5)))
+        self.assertFalse(self.game.map_contains(('default', 3, -1)))
+        self.assertFalse(self.game.map_contains(('default', 6, 4)))
+        self.assertFalse(self.game.map_contains(('default', 2, 12)))
+
+    def test_is_adjacent(self):
+        for col, row in [(1, 1), (1, 3), (2, 0), (2, 4), (3, 1), (3, 3)]:
+            self.assertTrue(
+                self.game.map_is_adjacent(('default', 2, 2), ('default', col, row)),
+                f"('default', {col}, {row}) is not adjacent to ('default', 2, 2)."
+            )
+
+    def test_not_adjacent_off_the_edge(self):
+        self.assertFalse(self.game.map_is_adjacent(('default', 4, 4), ('default', 5, 5)))
+
+    def test_not_adjacent_too_far(self):
+        self.assertFalse(self.game.map_is_adjacent(('default', 1, 3), ('default', 3, 1)))
+
+    def test_not_adjacent_wrong_phase(self):
+        self.assertFalse(self.game.map_is_adjacent(('default', 3, 3), ('default', 4, 3)))
+
+    def test_adjacent_list_middle(self):
+        self.assertCountEqual(
+            self.game.map_adjacent(('default', 2, 2)),
+            [('default', 1, 1), ('default', 1, 3), ('default', 2, 0),
+             ('default', 2, 4), ('default', 3, 1), ('default', 3, 3)]
+        )
+
+    def test_adjacent_list_edge(self):
+        self.assertCountEqual(
+            self.game.map_adjacent(('default', 4, 2)),
+            [('default', 3, 1), ('default', 3, 3), ('default', 4, 0), ('default', 4, 4)]
+        )
+
+    def test_adjacent_list_out_of_bounds(self):
+        self.assertCountEqual(self.game.map_adjacent(('default', 5, 5)), [])
+
+    def test_adjacent_list_wrong_phase(self):
+        self.assertCountEqual(self.game.map_adjacent(('default', 3, 2)), [])
+
+#     def test_terrain(self):
+#         terrain = type(_map.hexes[(0, 0)].terrain)
+#         self.assertEqual(len(_map.hexes), 13)
+#         self.assertEqual(sum(1 for co, H in _map.hexes.items() if H.terrain == terrain.PLAIN), 8)
+#         self.assertEqual(sum(1 for co, H in _map.hexes.items() if H.terrain == terrain.MOUNTAIN), 5)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
one for row-oriented hexmaps, and another for column-oriented hexmaps.

- [x] Implement row- vs. column-oriented hexmaps
- [x] checks for hex coordinates being within bounds and of legal parity
- [x] implement terrain
- [x] Add a `HexmapContainer` type, to glue together multiple hexmaps
- [x] implement hex equivalency within `HexmapContainer`
- [ ] implement edge terrain features
- [ ] implement cities
- [ ] implement resources
- [x] method to list all hexes adjacent to a hex
- [x] method to test hex adjacency
- [ ] method to get an adjacent hex given a hex plus direction
- [ ] method to get edge info from a hex in a direction
- [ ] method to get the hexes for a given city
- [ ] method to get the hexes providing a given resource
- [ ] method to give the build cost given a path
- [ ] method to give the move cost given a path
- [ ] method to return hex info given coordinates
- [ ] implement an easy way of initializing different game maps