### PR TITLE
Pile is being deprecated in amethyst.games, replace with a plain list

### DIFF
--- a/railroads/engine.py
+++ b/railroads/engine.py
@@ -1,14 +1,14 @@
 
 from amethyst.core  import Object, Attr
 from amethyst.games import action, Engine, EnginePlugin, Filter
-from amethyst.games.objects import Pile
+from amethyst.games.util import random
 from amethyst.games.plugins import GrantManager, Grant, Turns
 
 
 class RailroadEngine(Engine):
     map = Attr()
-    draw_pile = Attr(default=Pile)
-    discard_pile = Attr(default=Pile)
+    draw_pile = Attr(default=list)
+    discard_pile = Attr(default=list)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -46,6 +46,6 @@ class RailroadPlugin(EnginePlugin):
         game.discard_pile.extend(range(156))
 
     def shuffle(self, game):
-        game.discard_pile.shuffle()
-        deck = game.discard_pile.remove()
-        game.draw_pile.extend(deck)
+        random.shuffle(game.discard_pile)
+        game.draw_pile.extend(game.discard_pile)
+        game.discard_pile.clear()

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -44,8 +44,8 @@ class RailroadEngineTest(unittest.TestCase):
         game.initialize()
         game.call_immediate("begin")
 
-        self.assertEqual(game.discard_pile.count(), 0)
-        self.assertEqual(game.draw_pile.count(), 156)
+        self.assertEqual(len(game.discard_pile), 0)
+        self.assertEqual(len(game.draw_pile), 156)
 
     def test_draw(self):
         game = engine.RailroadEngine({'players': list(range(3))})
@@ -59,8 +59,8 @@ class RailroadEngineTest(unittest.TestCase):
             end_turn = game.list_grants(game.turn_player_num(), Filter(name='end_turn'))[0]
             game.trigger(game.turn_player(), end_turn.id, {})
             game.process_queue()
-            self.assertEqual(game.discard_pile.count(), p + 1)
-            self.assertEqual(game.draw_pile.count(), 156 - p - 1)
+            self.assertEqual(len(game.discard_pile), p + 1)
+            self.assertEqual(len(game.draw_pile), 156 - p - 1)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Pile() isn't realizing any tangible benefits, so I am removing it. This replaces your Pile() with plain list().